### PR TITLE
basic bundle support + minimal example

### DIFF
--- a/oLvosc_Lua_demo/oscdump.lua
+++ b/oLvosc_Lua_demo/oscdump.lua
@@ -1,24 +1,40 @@
 local oLvosc = require "oLv/oLvosc"
 -- +++++++++++++++++++++++++++++++++++++++++++++++++++
+
+--helper print function
+local function print_data(oscTYPE, dataT)
+  if dataT ~= nil then
+    for i, v in ipairs(dataT) do
+      local tc = oscTYPE:sub(i,i)
+      print('  '..i..')', tc, v)
+      if tc == 'm' then
+        print ('      MIDI: ', oLvosc.unpackMIDI(v))
+      end
+    end
+  end
+end
+
 -- poll the OSC server 
 function myServ(udp)
 	local packet = oLvosc.oscPoll(udp)
-	if packet ~= nil then
+	if packet == nil then return end
+
+  if oLvosc.isBundle(packet) then -- handle bundled messages
+    local msgs = oLvosc.oscUnpackBundle(packet)
+    -- simple print of all incoming data to console
+    for i, m in ipairs(msgs) do
+      local oscADDR, oscTYPE, oscDATA = table.unpack(m)
+      local dataT = oLvosc.oscDataUnpack(oscTYPE, oscDATA)
+      print(oscADDR, oscTYPE)
+      print_data(oscTYPE, dataT)
+    end
+  else  --handle a single message
     local oscADDR, oscTYPE, oscDATA = oLvosc.oscUnpack(packet)
     local dataT = oLvosc.oscDataUnpack(oscTYPE, oscDATA)
-      
-    -- simple print of all incoming data to console
     print(oscADDR, oscTYPE)
-    if dataT ~= nil then
-      for i, v in ipairs(dataT) do
-        local tc = oscTYPE:sub(i,i)
-        print('  '..i..')', tc, v)
-        if tc == 'm' then
-          print ('      MIDI: ', oLvosc.unpackMIDI(v))
-        end
-      end
-    end
-	end
+    print_data(oscTYPE, dataT)
+  end
+
 end
 -- +++++++++++++++++++++++++++++++++++++++++++++++++++
 -- OSC receive (server), listen to all


### PR DESCRIPTION
This library is exactly what I needed for my project (löve2d + non-blocking/threaded sockets) but it was missing bundle support. I thought I would take a crack at it and thankfully it didn't take too many lines to get it done. I followed the solution for bundles in https://github.com/mhroth/tinyosc and took advantage of as much of the code you already wrote

Main additions:
`isBundle(udpM)` - looks for the `#bundle` prefix
`oscUnpackBundle` - like `oscUnpack` but returns a table 1 or more tuples `{oscADDR, oscTYPE, oscDATA}`

I updated the `oscdump.lua` example to include bundle support